### PR TITLE
Store connection errors in an object property

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -116,6 +116,8 @@ class WP_Object_Cache {
 
 	var $stats_callback = null;
 
+	var $connection_errors = array();
+
 	function add( $id, $data, $group = 'default', $expire = 0 ) {
 		$key = $this->key( $id, $group );
 
@@ -479,7 +481,10 @@ class WP_Object_Cache {
 	}
 
 	function failure_callback( $host, $port ) {
-		// error_log("Connection failure for $host:$port\n", 3, '/tmp/memcached.txt');
+		$this->connection_errors[] = array(
+			'host' => $host,
+			'port' => $port,
+		);
 	}
 
 	function salt_keys( $key_salt ) {


### PR DESCRIPTION
In case we need to track and handle errors in some way later on during the load process. We could trigger an action but the cache object is initialized before mu-plugins so we can't actually hook in.

/cc @simonwheatley re: https://github.com/Automattic/vip-go-mu-plugins/pull/386