### PR TITLE
Don't allow expiry > 30 days

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -113,6 +113,7 @@ class WP_Object_Cache {
 
 	var $cache_enabled      = true;
 	var $default_expiration = 0;
+	var $max_expiration     = 30 * DAY_IN_SECONDS;
 
 	var $stats_callback = null;
 
@@ -133,7 +134,11 @@ class WP_Object_Cache {
 
 		$mc =& $this->get_mc( $group );
 
-		$expire = ( 0 == $expire ) ? $this->default_expiration : $expire;
+		$expire = absint( $expire );
+		if ( 0 === $expire || $expire > $this->max_expiration ) {
+			$expire = $this->default_expiration;
+		}
+
 		$result = $mc->add( $key, $data, false, $expire );
 
 		if ( false !== $result ) {
@@ -401,7 +406,11 @@ class WP_Object_Cache {
 			return true;
 		}
 
-		$expire = ( 0 == $expire ) ? $this->default_expiration : $expire;
+		$expire = absint( $expire );
+		if ( 0 === $expire || $expire > $this->max_expiration ) {
+			$expire = $this->default_expiration;
+		}
+
 		$mc     =& $this->get_mc( $group );
 		$result = $mc->set( $key, $data, false, $expire );
 


### PR DESCRIPTION
That is the max that memcached allows.

This is often due to incorrect data being passed in, like a timestamp, which often tends to be in the past (e.g. `YEAR_IN_SECONDS`) and therefore instantly expires.

https://github.com/memcached/memcached/wiki/Programming#expiration