### PR TITLE
Remove local empty cache in case the remove add action fails

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -148,6 +148,13 @@ class WP_Object_Cache {
 
 			$this->group_ops[ $group ][] = "add $id";
 			$this->cache[ $key ]         = $data;
+		} else if ( false === $result && true === isset( $this->cache[$key] ) && false === $this->cache[$key] ) {
+			/*
+			 * Here we unset local cache if remote add failed and local cache value is equal to `false` in order
+			 * to update the local cache anytime we get a new information from remote server. This way, the next
+			 * cache get will go to remote server and will fetch recent data.
+			 */
+			unset( $this->cache[$key] );
 		}
 
 		return $result;


### PR DESCRIPTION
Props @david-binda

This changeset is applying a logic for keeping remote and local cache in sync based on the information we get from remote actions. In case a code calls remote add action and it fails, it's b/c there is already a value stored in memcache server. By removing the local, in memory, cache key-value pair, we make sure that the very next get call will make it to the remote server and will update the local cache with appropriate data.

The code is only removing the local cache in case it's value is equal to `false`, since if we were not doing so, various cache priming functions using add (eg.: update_site_cache, update_term_cache, update_post_cache) would introduced even more SQL queries that we are currently seeing due to alloptions.