### PR TITLE
Increase version number of plugin since last changes.

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Memcached
 Description: Memcached backend for the WP Object Cache.
-Version: 3.0.1
+Version: 3.1.0
 Plugin URI: http://wordpress.org/extend/plugins/memcached/
 Author: Ryan Boren, Denis de Bernardy, Matt Martz, Andy Skelton
 


### PR DESCRIPTION
There were some big changes made recently but the version number wasn't
changed. We should increase to make it obvious that this version is
different.

As the changes are not technically breaking changes I've not gone to
4.0.0 but let me know if you believe we should.