### PR TITLE
Fix "undefined index" warning in stats colorizer for get_multi command

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -511,6 +511,7 @@ class WP_Object_Cache {
 	function colorize_debug_line( $line ) {
 		$colors = array(
 			'get' => 'green',
+			'get_multi' => 'green',
 			'set' => 'purple',
 			'add' => 'blue',
 			'delete' => 'red',

--- a/object-cache.php
+++ b/object-cache.php
@@ -518,7 +518,15 @@ class WP_Object_Cache {
 
 		$cmd = substr( $line, 0, strpos( $line, ' ' ) );
 
-		$cmd2 = "<span style='color:{$colors[$cmd]}'>$cmd</span>";
+		// Start off with a neutral default color...
+		$color_for_cmd = 'brown';
+
+		// And if the cmd has a specific color, use that instead
+		if ( isset( $colors[ $cmd ] ) ) {
+			$color_for_cmd = $colors[ $cmd ];
+		}
+
+		$cmd2 = "<span style='color:{$color_for_cmd}'>$cmd</span>";
 
 		return $cmd2 . substr( $line, strlen( $cmd ) ) . "\n";
 	}

--- a/object-cache.php
+++ b/object-cache.php
@@ -527,9 +527,9 @@ class WP_Object_Cache {
 			$color_for_cmd = $colors[ $cmd ];
 		}
 
-		$cmd2 = "<span style='color:{$color_for_cmd}'>$cmd</span>";
+		$cmd2 = '<span style="color:' . esc_attr( $color_for_cmd ) . '">' . esc_html( $cmd ) . '</span>';
 
-		return $cmd2 . substr( $line, strlen( $cmd ) ) . "\n";
+		return $cmd2 . esc_html( substr( $line, strlen( $cmd ) ) ) . "\n";
 	}
 
 	function stats() {

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -891,4 +891,54 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		$this->assertFalse( $found );
 	}
+
+	public function get_colorize_debug_line_data() {
+		return array(
+			array(
+				// Command
+				'get foo',
+				// Expected color
+				'green',
+			),
+			array(
+				// Command
+				'get_multi foo',
+				// Expected color
+				'green',
+			),
+			array(
+				// Command
+				'set foo',
+				// Expected color
+				'purple',
+			),
+			array(
+				// Command
+				'add foo',
+				// Expected color
+				'blue',
+			),
+			array(
+				// Command
+				'delete foo',
+				// Expected color
+				'red',
+			),
+			array(
+				// Command
+				'unknown foo',
+				// Expected color
+				'brown', // Default
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_colorize_debug_line_data
+	 */
+	public function test_colorize_debug_line( $command, $expected_color ) {
+		$colorized = $this->object_cache->colorize_debug_line( $command );
+
+		$this->assertContains( $expected_color, $colorized );
+	}
 }


### PR DESCRIPTION
Sets a default color for commands in the stats colorizer function to prevent undefined index errors when a color is not defined. Also defines `green` for `get_multi` (to match `get`).

```
PHP Notice:  Undefined index: get_multi in /var/www/wp-content/object-cache.php on line 521
```

## Testing

1. Pull PR
1. Navigate through site
1. Check Debug Bar panel for correct coloring in cache command names
1. Ensure there are no PHP notices for undefined index `get_multi`

