### PR TITLE
Add test for the wp_cache_get $found variable

### DIFF
--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -891,4 +891,16 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		$this->assertFalse( $found );
 	}
+	
+	public function test_found_wp_cache_get() {
+		$found = null;
+		
+		// Force to read from cache
+		wp_cache_get( 'foo', null, true, $found );
+		$this->assertFalse( $found );
+		
+		wp_cache_set( 'foo', false );
+		wp_cache_get( 'foo', null, true, $found );
+		$this->assertTrue( $found );
+	}
 }


### PR DESCRIPTION
Tests whether the $found variable works for memcached operations. We bypass the local in-memory cache to force wp_cache_get to do a remote operation.