### PR TITLE
Bump "tested up to" to WordPress 5.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: ryan, sivel, andy
 Tags: cache, memcached
 Requires at least: 3.0
-Tested up to: 4.7
+Tested up to: 5.4
 Stable tag: 3.1.0
 
 Use memcached and the PECL memcache extension to provide a backing store for the WordPress object cache.


### PR DESCRIPTION
Props @paulschreiber for flagging this.