### PR TITLE
Support for wp_cache_get_multiple()

### DIFF
--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -509,8 +509,8 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		);
 
 		$expected = [
-			$this->object_cache->key( 'foo', 'default') => 'data',
-			$this->object_cache->key( 'foo', 'another-group') => 'data',
+			'default:foo' => 'data',
+			'another-group:foo' => 'data',
 		];
 
 		$this->assertEquals( $expected, $values );
@@ -581,9 +581,9 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		);
 
 		$expected = [
-			$this->object_cache->key( 'foo', 'default') => 'data-updated',
-			$this->object_cache->key( 'foo', 'another-group') => 'data',
-			$this->object_cache->key( 'foo', 'and-another-group') => 'data',
+			'default:foo' => 'data-updated',
+			'another-group:foo' => 'data',
+			'and-another-group:foo' => 'data',
 		];
 
 		$this->assertEquals( $expected, $values );
@@ -618,9 +618,9 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		);
 
 		$expected = [
-			$this->object_cache->key( 'foo', 'default') => 'data',
-			$this->object_cache->key( 'foo', 'another-group') => 'data',
-			$this->object_cache->key( 'foo', 'and-another-group') => 'data',
+			'default:foo' => 'data',
+			'another-group:foo' => 'data',
+			'and-another-group:foo' => 'data',
 		];
 
 		$this->assertEquals( $expected, $values );
@@ -633,7 +633,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		$this->object_cache->add( 'foo', 'data', $group );
 
 		$values = $this->object_cache->get_multi( [ $group => [ 'foo' ] ] );
-		$expected = [ $this->object_cache->key( 'foo', $group ) => 'data' ];
+		$expected = [ $group . ':foo' => 'data' ];
 		$this->assertEquals( $expected, $values );
 
 		$expected_cache = [
@@ -654,7 +654,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		unset( $this->object_cache->cache[ $key ] );
 
 		$values = $this->object_cache->get_multi( [ $group => [ 'foo' ] ] );
-		$expected = [ $this->object_cache->key( 'foo', $group ) => false ];
+		$expected = [ $group . ':foo' => false ];
 
 		$this->assertEquals( $expected, $values );
 		$this->assertFalse( $this->object_cache->cache[ $key ][ 'value' ] );


### PR DESCRIPTION
Add support for the new `wp_cache_get_multiple()` method added in WordPress 5.5

Part of the code has been reused from legacy `wp_cache_get_multi()`, although the new implementation uses actual memcache multiget requests instead of individual gets in a loop. This means it could be used efficiently for code that requires obtaining many cached objects at once.

It returns an array with this format:

```
wp_cache_get_multiple( array( 'key_id1', 'key_id2' ), 'group' );
array(
   'key_id1' => 'value1',
   'key_id2' => 'value2',
);
```

Where `key_id1` and `key_id2` are exactly the same keys as requested, following the format that is returned by the reference `wp_cache_get_multiple()` in WordPress 5.5.

The legacy method `wp_cache_get_multi()` is kept for backwards compatibility, although it has changed the response format. So far it returned the full memcached key (including the salt and prefix), and now it just returns the group and key identifier:

```
wp_cache_get_multi( array( 'group1' => array( 'key_id1' ), 'group2' => array( 'key_id2' ) ) );
array (
   'group1:key_id1' => 'value1',
   'group2:key_id2' => 'value2',
);
```
The expectation of this breaking any code is low, as the original response format invited to just ignore the keys (as they didn't match the requested keys) and use the returned values.

Fixes #63 