### PR TITLE
Add wp_cache_get_pre filter

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -57,7 +57,7 @@ function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
 
 	$value = apply_filters( 'wp_cache_get_pre', false, $key, $group, $force );
 	if ( false !== $value ) {
-		return $value
+		return $value;
 	}
 
 	return $wp_object_cache->get( $key, $group, $force, $found );

--- a/object-cache.php
+++ b/object-cache.php
@@ -55,7 +55,7 @@ function wp_cache_flush() {
 function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
 	global $wp_object_cache;
 
-	$value = apply_filters( 'wp_cache_get_pre', false, $key, $group, $force );
+	$value = apply_filters( 'pre_wp_cache_get', false, $key, $group, $force );
 	if ( false !== $value ) {
 		return $value;
 	}

--- a/object-cache.php
+++ b/object-cache.php
@@ -55,6 +55,11 @@ function wp_cache_flush() {
 function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
 	global $wp_object_cache;
 
+	$value = apply_filters( 'wp_cache_get_pre', false, $key, $group, $force );
+	if ( false !== $value ) {
+		return $value
+	}
+
 	return $wp_object_cache->get( $key, $group, $force, $found );
 }
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -57,6 +57,7 @@ function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
 
 	$value = apply_filters( 'pre_wp_cache_get', false, $key, $group, $force );
 	if ( false !== $value ) {
+		$found = true;
 		return $value;
 	}
 


### PR DESCRIPTION
This will let us short-circuit the memcached request. The initial use-case here is to intercept hot keys to store them in a local apcu cache.