### PR TITLE
Group list: Fix float and font size

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -621,7 +621,7 @@ class WP_Object_Cache {
 			echo '</h2>';
 		}
 
-		echo "<ul class='debug-menu-links'>\n";
+		echo "<ul class='debug-menu-links' style='clear:left;font-size:14px;'>\n";
 		$groups = array_keys( $this->group_ops );
 		usort( $groups, 'strnatcasecmp' );
 


### PR DESCRIPTION
The list of links groups is floated, but for narrow windows, the list will wrap around the top stats in the Debug Bar panel. This PR clears the float, and increases the font size to make it a little more readable.

Before:
<img width="1091" alt="Screenshot 2020-10-16 at 11 16 26" src="https://user-images.githubusercontent.com/88371/96246884-351a4f00-0fa1-11eb-9bc1-ea374678616f.png">

After:
<img width="1091" alt="Screenshot 2020-10-16 at 11 16 45" src="https://user-images.githubusercontent.com/88371/96246890-36e41280-0fa1-11eb-81ee-2b65e64a9b8f.png">
