### PR TITLE
Proof of concept: Confirm memcached is giving the correct response

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -326,7 +326,15 @@ class WP_Object_Cache {
 		} else {
 			$flags = false;
 			$this->timer_start();
-			$value = $mc->get( $key, $flags );
+
+			// Sending as an array so we can verify the key being returned is what we asked for.
+			$value = $mc->get( [ $key ], $flags );
+			if ( is_array( $value ) && isset( $value[ $key ] ) ) {
+				$value = $value[ $key ];
+			} else {
+				$value = false;
+			}
+
 			$elapsed = $this->timer_stop();
 
 			// Value will be unchanged if the key doesn't exist.
@@ -404,7 +412,14 @@ class WP_Object_Cache {
 
 					continue;
 				} else {
-					$fresh_get = $mc->get( $key );
+					// Sending as an array so we can verify the key being returned is what we asked for.
+					$fresh_get = $mc->get( [ $key ] );
+					if ( is_array( $fresh_get ) && isset( $fresh_get[ $key ] ) ) {
+						$fresh_get = $fresh_get[ $key ];
+					} else {
+						$fresh_get = false;
+					}
+
 					$return[ $key ] = $fresh_get;
 					$return_cache[ $key ] = [
 						'value' => $fresh_get,


### PR DESCRIPTION
If you send an array, the memcache client will respond with an associative array: https://www.php.net/manual/en/memcache.get.php. With this, we can ensure that the memcached server is giving us the correct response.

This is just a proof of concept for now. Some further ideas include:

- Checking if it returns an array but with the wrong key, and log an error and retry once if so.
- Doing this in the memcache php client extension instead.

As a side note, we should really be making use of this functionality for the multi_get() logic that WP now uses - as it can greatly limit the # of roundtrips to the memcached server. But can come back to that another day :).