### PR TITLE
Add flush_number replication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
     - sudo apt-get install zlib1g-dev
     - pecl channel-update pecl.php.net
     - pecl config-set preferred_state beta
-    - echo 'yes' | pecl install memcache
+    - echo 'yes' | pecl install memcache-4.0.5.2
     - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
     - pecl channel-update pecl.php.net
     - pecl config-set preferred_state beta
     - echo 'yes' | pecl install memcache-4.0.5.2
-    - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - phpenv config-rm xdebug.ini
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
     - pecl config-set preferred_state beta
     - echo 'yes' | pecl install memcache-4.0.5.2
     - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - phpenv config-rm xdebug.ini
 
 install:
     - composer update --prefer-dist --prefer-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ services:
 
 env:
     global:
-        - MEMCACHED__HOST=localhost WP_VERSION=latest WP_MULTISITE=0 #Current stable release
+        - MEMCACHED__HOST=localhost
+        - WP_VERSION=latest
+        - WP_MULTISITE=0
         - XDEBUG_MODE=coverage
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
     - pecl channel-update pecl.php.net
     - pecl config-set preferred_state beta
     - echo 'yes' | pecl install memcache-4.0.5.2
-    - phpenv config-rm xdebug.ini
 
 install:
     - composer update --prefer-dist --prefer-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
         - MEMCACHED__HOST=localhost
         - WP_VERSION=latest
         - WP_MULTISITE=0
-        - XDEBUG_MODE=coverage
+        - XDEBUG_MODE=off
 
 before_install:
     - sudo apt-get install gcc make autoconf libc-dev pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
 
 env:
     - MEMCACHED__HOST=localhost WP_VERSION=latest WP_MULTISITE=0 #Current stable release
+    - XDEBUG_MODE=coverage
 
 before_install:
     - sudo apt-get install gcc make autoconf libc-dev pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ services:
     - memcached
 
 env:
-    - MEMCACHED__HOST=localhost WP_VERSION=latest WP_MULTISITE=0 #Current stable release
-    - XDEBUG_MODE=coverage
+    global:
+        - MEMCACHED__HOST=localhost WP_VERSION=latest WP_MULTISITE=0 #Current stable release
+        - XDEBUG_MODE=coverage
 
 before_install:
     - sudo apt-get install gcc make autoconf libc-dev pkg-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
         - MEMCACHED__HOST=localhost
         - WP_VERSION=latest
         - WP_MULTISITE=0
-        - XDEBUG_MODE=off
+        - XDEBUG_MODE=coverage
 
 before_install:
     - sudo apt-get install gcc make autoconf libc-dev pkg-config

--- a/object-cache.php
+++ b/object-cache.php
@@ -283,7 +283,7 @@ class WP_Object_Cache {
 		$key = $this->key( $this->flush_key, $group );
 
 		$values = array();
-		$size = 19;
+		$size = 19; // size of microsecond timestamp serialized
 		foreach ( $this->default_mcs as $i => $mc ) {
 			$flags = false;
 			$this->timer_start();
@@ -305,7 +305,6 @@ class WP_Object_Cache {
 
 		// Replicate to servers not having the max.
 		$expire = 0;
-		$size = 19;
 		foreach ( $this->default_mcs as $i => $mc ) {
 			if ( $values[ $i ] < $max ) {
 				$this->timer_start();

--- a/object-cache.php
+++ b/object-cache.php
@@ -121,11 +121,16 @@ class WP_Object_Cache {
 
 	var $no_mc_groups = array();
 
-	var $cache     = array();
-	var $mc        = array();
-	var $stats     = array();
-	var $group_ops = array();
+	var $cache       = array();
+	var $mc          = array();
+	var $default_mcs = array();
+	var $stats       = array();
+	var $group_ops   = array();
 
+	var $flush_group         = 'WP_Object_Cache';
+	var $global_flush_group  = 'WP_Object_Cache_global';
+	var $flush_key           = "flush_number_v4";
+	var $old_flush_key       = "flush_number";
 	var $flush_number        = array();
 	var $global_flush_number = null;
 
@@ -273,31 +278,132 @@ class WP_Object_Cache {
 		return $result;
 	}
 
+	// Gets number from all default servers, replicating if needed
+	function get_max_flush_number( $group ) {
+		$key = $this->key( $this->flush_key, $group );
+
+		$values = array();
+		$size = 19;
+		foreach ( $this->default_mcs as $i => $mc ) {
+			$flags = false;
+			$this->timer_start();
+			$values[ $i ] = $mc->get( $key, $flags );
+			$elapsed = $this->timer_stop();
+
+			if ( empty( $values[ $i ] ) ) {
+				$this->group_ops_stats( 'get_flush_number', $key, $group, null, $elapsed, 'not_in_memcache' );
+			} else {
+				$this->group_ops_stats( 'get_flush_number', $key, $group, $size, $elapsed, 'memcache' );
+			}
+		}
+
+		$max = max( $values );
+
+		if ( ! $max > 0 ) {
+			return false;
+		}
+
+		// Replicate to servers not having the max.
+		$expire = 0;
+		$size = 19;
+		foreach ( $this->default_mcs as $i => $mc ) {
+			if ( $values[ $i ] < $max ) {
+				$this->timer_start();
+				$mc->set( $key, $max, false, $expire );
+				$elapsed = $this->timer_stop();
+				$this->group_ops_stats( 'set_flush_number', $key, $group, $size, $elapsed, 'replication_repair' );
+			}
+		}
+
+		return $max;
+	}
+
+	function set_flush_number( $value, $group ) {
+		$key = $this->key( $this->flush_key, $group );
+		$expire = 0;
+		$size = 19;
+		foreach ( $this->default_mcs as $i => $mc ) {
+			$this->timer_start();
+			$mc->set( $key, $value, false, $expire );
+			$elapsed = $this->timer_stop();
+			$this->group_ops_stats( 'set_flush_number', $key, $group, $size, $elapsed, 'replication' );
+		}
+	}
+
+	function get_flush_number( $group ) {
+		$flush_number = $this->get_max_flush_number( $group );
+		// What if there is no v4 flush number?
+		if ( empty( $flush_number ) ) {
+			// Look for the v3 flush number key.
+			$flush_number = intval( $this->get( $this->old_flush_key, $group ) );
+			if ( !empty( $flush_number ) ) {
+				// Found v3 flush number. Upgrade to v4 with replication.
+				$this->set_flush_number( $flush_number, $group );
+				// Delete v3 key so we can't later restore it and find stale keys.
+			} else {
+				// No flush number found anywhere. Make a new one. This flushes the cache.
+				$flush_number = $this->new_flush_number();
+				$this->set_flush_number( $flush_number, $group );
+			}
+		}
+
+		return $flush_number;
+	}
+
+	function get_global_flush_number() {
+		if ( ! isset( $this->global_flush_number ) ) {
+			$this->global_flush_number = $this->get_flush_number( $this->global_flush_group );
+		}
+		return $this->global_flush_number;
+	}
+
+	function get_blog_flush_number() {
+		if ( ! isset( $this->flush_number[ $this->blog_prefix ] ) ) {
+			$this->flush_number[ $this->blog_prefix ] = $this->get_flush_number( $this->flush_group );
+		}
+		return $this->flush_number[ $this->blog_prefix ];
+	}
+
 	function flush() {
 		// Do not use the memcached flush method. It acts on an
 		// entire memcached server, affecting all sites.
 		// Flush is also unusable in some setups, e.g. twemproxy.
 		// Instead, rotate the key prefix for the current site.
-		// Global keys are rotated when flushing on the main site.
+		// Global keys are rotated when flushing on any network's
+		// main site.
 		$this->cache = array();
 
-		$this->rotate_site_keys();
+		$flush_number = $this->new_flush_number();
+
+		$this->rotate_site_keys( $flush_number );
 
 		if ( is_main_site() ) {
-			$this->rotate_global_keys();
+			$this->rotate_global_keys( $flush_number );
 		}
 	}
 
-	function rotate_site_keys() {
-		$this->add( 'flush_number', intval( microtime( true ) * 1e6 ), 'WP_Object_Cache' );
+	function rotate_site_keys( $flush_number = null ) {
+		if ( is_null( $flush_number ) ) {
+			$flush_number = $this->new_flush_number();
+		}
 
-		$this->flush_number[ $this->blog_prefix ] = $this->incr( 'flush_number', 1, 'WP_Object_Cache' );
+		$this->set_flush_number( $flush_number, $this->flush_group );
+
+		$this->flush_number[ $this->blog_prefix ] = $flush_number;
 	}
 
-	function rotate_global_keys() {
-		$this->add( 'flush_number', intval( microtime( true ) * 1e6 ), 'WP_Object_Cache_global' );
+	function rotate_global_keys( $flush_number = null ) {
+		if ( is_null( $flush_number ) ) {
+			$flush_number = $this->new_flush_number();
+		}
 
-		$this->global_flush_number = $this->incr( 'flush_number', 1, 'WP_Object_Cache_global' );
+		$this->set_flush_number( $flush_number, $this->global_flush_group );
+
+		$this->global_flush_number = $flush_number;
+	}
+
+	function new_flush_number() {
+		return intval( microtime( true ) * 1e6 );
 	}
 
 	function get( $id, $group = 'default', $force = false, &$found = null ) {
@@ -423,31 +529,14 @@ class WP_Object_Cache {
 	}
 
 	function flush_prefix( $group ) {
-		if ( 'WP_Object_Cache' === $group || 'WP_Object_Cache_global' === $group ) {
+		if ( $group === $this->flush_group || $group === $this->global_flush_group ) {
 			// Never flush the flush numbers.
 			$number = '_';
 		} elseif ( false !== array_search( $group, $this->global_groups ) ) {
-			if ( ! isset( $this->global_flush_number ) ) {
-				$this->global_flush_number = intval( $this->get( 'flush_number', 'WP_Object_Cache_global' ) );
-			}
-
-			if ( 0 === $this->global_flush_number ) {
-				$this->rotate_global_keys();
-			}
-
-			$number = $this->global_flush_number;
+			$number = $this->get_global_flush_number();
 		} else {
-			if ( ! isset( $this->flush_number[ $this->blog_prefix ] ) ) {
-				$this->flush_number[ $this->blog_prefix ] = intval( $this->get( 'flush_number', 'WP_Object_Cache' ) );
+			$number = $this->get_blog_flush_number();
 			}
-
-			if ( 0 === $this->flush_number[ $this->blog_prefix ] ) {
-				$this->rotate_site_keys();
-			}
-
-			$number = $this->flush_number[ $this->blog_prefix ];
-		}
-
 		return $number . ':';
 	}
 
@@ -760,7 +849,7 @@ class WP_Object_Cache {
 		foreach ( $buckets as $bucket => $servers ) {
 			$this->mc[ $bucket ] = new Memcache();
 
-			foreach ( $servers as $server  ) {
+			foreach ( $servers as $i => $server  ) {
 				if ( 'unix://' == substr( $server, 0, 7 ) ) {
 					$node = $server;
 					$port = 0;
@@ -780,6 +869,12 @@ class WP_Object_Cache {
 
 				$this->mc[ $bucket ]->addServer( $node, $port, true, 1, 1, 15, true, array( $this, 'failure_callback' ) );
 				$this->mc[ $bucket ]->setCompressThreshold( 20000, 0.2 );
+
+				// Prepare individual connections to servers in default bucket for flush_number redundancy
+				if ( 'default' === $bucket ) {
+					$this->default_mcs[ $i ] = new Memcache();
+					$this->default_mcs[ $i ]->addServer( $node, $port, true, 1, 1, 15, true, array( $this, 'failure_callback' ) );
+				}
 			}
 		}
 
@@ -832,10 +927,10 @@ class WP_Object_Cache {
 	}
 
 	/**
-	 * Key format: key_salt:flush_timer:table_prefix:key_name
+	 * Key format: key_salt:flush_number:table_prefix:key_name
 	 *
-	 * We want to strip the `key_salt:flush_timer` part to not leak the memcached keys.
-	 * If `key_salt` is set we strip `'key_salt:flush_timer`, otherwise just strip the `flush_timer` part.
+	 * We want to strip the `key_salt:flush_number` part to not leak the memcached keys.
+	 * If `key_salt` is set we strip `'key_salt:flush_number`, otherwise just strip the `flush_number` part.
 	 */
 	function strip_memcached_keys( $keys ) {
 		if ( ! is_array( $keys ) ) {

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -673,7 +673,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		$this->assertEmpty( $this->object_cache->global_flush_number );
 
-		$global_flush_number = (int) $this->object_cache->get( 'flush_number', 'WP_Object_Cache_global' );
+		$global_flush_number = (int) $this->object_cache->get( $this->object_cache->flush_key, 'WP_Object_Cache_global' );
 		$this->assertEquals( $global_flush_number . ':', $this->object_cache->flush_prefix( 'global-group' ) );
 		$this->assertEquals( $global_flush_number, $this->object_cache->global_flush_number );
 
@@ -686,7 +686,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 	public function test_flush_prefix_sets_flush_number_for_non_global_groups(): void {
 		$this->assertArrayNotHasKey( $this->object_cache->blog_prefix, $this->object_cache->flush_number );
 
-		$flush_number = (int) $this->object_cache->get( 'flush_number', 'WP_Object_Cache' );
+		$flush_number = (int) $this->object_cache->get( $this->object_cache->flush_key, 'WP_Object_Cache' );
 		$this->assertEquals( $flush_number . ':', $this->object_cache->flush_prefix( 'non-global-group' ) );
 		$this->assertEquals( $flush_number, $this->object_cache->flush_number[ $this->object_cache->blog_prefix ] );
 

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -664,8 +664,8 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 	// Tests for flush_prefix.
 
 	public function test_flush_prefix_is_underscore_for_flush_number_groups(): void {
-		$this->assertEquals( '_:', $this->object_cache->flush_prefix( 'WP_Object_Cache' ) );
-		$this->assertEquals( '_:', $this->object_cache->flush_prefix( 'WP_Object_Cache_global' ) );
+		$this->assertEquals( '_:', $this->object_cache->flush_prefix( $this->object_cache->flush_group ) );
+		$this->assertEquals( '_:', $this->object_cache->flush_prefix( $this->object_cache->global_flush_group ) );
 	}
 
 	public function test_flush_prefix_sets_global_flush_number_for_global_groups(): void {
@@ -673,7 +673,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		$this->assertEmpty( $this->object_cache->global_flush_number );
 
-		$global_flush_number = (int) $this->object_cache->get( $this->object_cache->flush_key, 'WP_Object_Cache_global' );
+		$global_flush_number = (int) $this->object_cache->get( $this->object_cache->flush_key, $this->object_cache->global_flush_group );
 		$this->assertEquals( $global_flush_number . ':', $this->object_cache->flush_prefix( 'global-group' ) );
 		$this->assertEquals( $global_flush_number, $this->object_cache->global_flush_number );
 
@@ -686,7 +686,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 	public function test_flush_prefix_sets_flush_number_for_non_global_groups(): void {
 		$this->assertArrayNotHasKey( $this->object_cache->blog_prefix, $this->object_cache->flush_number );
 
-		$flush_number = (int) $this->object_cache->get( $this->object_cache->flush_key, 'WP_Object_Cache' );
+		$flush_number = (int) $this->object_cache->get( $this->object_cache->flush_key, $this->object_cache->flush_group );
 		$this->assertEquals( $flush_number . ':', $this->object_cache->flush_prefix( 'non-global-group' ) );
 		$this->assertEquals( $flush_number, $this->object_cache->flush_number[ $this->object_cache->blog_prefix ] );
 


### PR DESCRIPTION
Add flush_number replication to prevent accidental flush due to flush_number eviction, server rotation, etc.

Caches aren't flushed by telling memcached to flush itself because the memcached server could be hosting caches for multiple sites. So caches are flushed by changing the cache keys for only the site that needs flushing. Each site has its own flush_number which is automatically included in its cache keys. When the flush_number changes, all of the old keys become inaccessible, effectively flushing the cache for just that site.

Cache flushes could happen randomly when flush_number gets evicted. In setups with multiple cache servers, this can be prevented by storing the flush_number in all of the cache servers, keeping the values in sync, and always using the latest value.

Cache flushes also happen when a memcached server is restarted. In setups with N cache servers, the restart of a single server has a 1/N probability of taking with it the flush_number, effectively flushing all of the keys instead of only the keys on the restarted server. Storing the flush_number on each server prevents these unwanted full-cache flushes.