### PR TITLE
Latest memcache extension requires PHP version >=8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
     - sudo apt-get install zlib1g-dev
     - pecl channel-update pecl.php.net
     - pecl config-set preferred_state beta
-    - echo 'yes' | pecl install memcache
+    - echo 'yes' | pecl install memcache-4.0.5.2
     - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:


### PR DESCRIPTION
Fix tests.