### PR TITLE
CI: Add workflow to deploy to wordpress.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: memcached


### PR DESCRIPTION
To keep code in sync between different sources, we can have tags made in Git and pushed to GitHub, automatically make a push to the WordPress.org tag and trunk directories.

See https://github.com/10up/action-wordpress-plugin-deploy.

`SLUG` included as the GitHub repo slug and the slug on wordpress.org are different.

Doesn't appear to be a build process for this repo, so I've removed that step.

A SVN committer's SVN password and username will need to be added to this repo's settings for it to work. The plugin doesn't have `Automattic` as a committer.