### PR TITLE
Fix CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.4"
+      "php": "7.3"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,12 @@
     "composer/installers": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7",
+    "yoast/phpunit-polyfills": "^1.0"
+  },
+  "config": {
+    "platform": {
+      "php": "7.4"
+    }
   }
 }


### PR DESCRIPTION
CI [failed](https://travis-ci.org/github/Automattic/wp-memcached/jobs/774809271) because of the missing PHPUnit Polyfills library. This PR fixes that and makes tests pass again.
