### PR TITLE
Update PHPUnit, CI, add support for running tests in Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 clover.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,7 @@ before_install:
     - sudo apt-get install zlib1g-dev
     - pecl channel-update pecl.php.net
     - pecl config-set preferred_state beta
-    - |
-        if [ php -r 'echo PHP_MAJOR_VERSION;' | grep -q 7 ]; then
-            echo 'yes' | pecl install memcache-4.0.5.2
-        else
-            echo 'yes' | pecl install memcache-8.0
-        fi
+    - if php -r 'echo PHP_MAJOR_VERSION;' | grep -q 7; then echo 'yes' | pecl install memcache-4.0.5.2; else echo 'yes' | pecl install memcache-8.0; fi
 
 install:
     - composer update --prefer-dist --prefer-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-    - "7.3"
     - "7.4"
+    - "8.0"
 
 services:
     - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,12 @@ before_install:
     - sudo apt-get install zlib1g-dev
     - pecl channel-update pecl.php.net
     - pecl config-set preferred_state beta
-    - echo 'yes' | pecl install memcache-4.0.5.2
+    - |
+        if [ php -r 'echo PHP_MAJOR_VERSION;' | grep -q 7 ]; then
+            echo 'yes' | pecl install memcache-4.0.5.2
+        else
+            echo 'yes' | pecl install memcache-8.0
+        fi
 
 install:
     - composer update --prefer-dist --prefer-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: focal
+
 php:
     - "7.4"
     - "8.0"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,148 @@
+#!/bin/sh
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --wp)
+            shift
+            WP_VERSION="$1"
+        ;;
+
+        --multisite)
+            shift
+            WP_MULTISITE="$1"
+        ;;
+
+        --php)
+            shift
+            PHP_VERSION="$1"
+        ;;
+
+        --php-options)
+            shift
+            PHP_OPTIONS="$1"
+        ;;
+
+        --phpunit)
+            shift
+            PHPUNIT_VERSION="$1"
+        ;;
+
+        --network)
+            shift
+            NETWORK_NAME_OVERRIDE="$1"
+        ;;
+
+        --dbhost)
+            shift
+            MYSQL_HOST_OVERRIDE="$1"
+        ;;
+
+        --docker-options)
+            shift
+            DOCKER_OPTIONS="$1"
+        ;;
+
+        *)
+            ARGS="${ARGS} $1"
+        ;;
+    esac
+
+    shift
+done
+
+: "${WP_VERSION:=latest}"
+: "${WP_MULTISITE:=0}"
+: "${PHP_VERSION:=""}"
+: "${PHP_OPTIONS:=""}"
+: "${PHPUNIT_VERSION:=""}"
+: "${DOCKER_OPTIONS:=""}"
+
+PHP_OPTIONS="-d apc.enable_cli=1 ${PHP_OPTIONS}"
+
+export WP_VERSION
+export WP_MULTISITE
+export PHP_VERSION
+export PHP_OPTIONS
+export PHPUNIT_VERSION
+
+echo "--------------"
+echo "Will test with WP_VERSION=${WP_VERSION} and WP_MULTISITE=${WP_MULTISITE}"
+echo "--------------"
+echo
+
+MARIADB_VERSION="10.3"
+
+UUID=$(date +%s000)
+if [ -z "${NETWORK_NAME_OVERRIDE}" ]; then
+    NETWORK_NAME="tests-${UUID}"
+    docker network create "${NETWORK_NAME}"
+else
+    NETWORK_NAME="${NETWORK_NAME_OVERRIDE}"
+fi
+
+export MYSQL_USER=wordpress
+export MYSQL_PASSWORD=wordpress
+export MYSQL_DATABASE=wordpress_test
+
+db=""
+if [ -z "${MYSQL_HOST_OVERRIDE}" ]; then
+    MYSQL_HOST="db-${UUID}"
+    db=$(docker run --rm --network "${NETWORK_NAME}" --name "${MYSQL_HOST}" -e MYSQL_ROOT_PASSWORD="wordpress" -e MARIADB_INITDB_SKIP_TZINFO=1 -e MYSQL_USER -e MYSQL_PASSWORD -e MYSQL_DATABASE -d "mariadb:${MARIADB_VERSION}")
+else
+    MYSQL_HOST="${MYSQL_HOST_OVERRIDE}"
+fi
+
+export MYSQL_HOST
+
+export MEMCACHED_HOST_1="mc1-${UUID}"
+export MEMCACHED_HOST_2="mc2-${UUID}"
+mc1=$(docker run --rm --network "${NETWORK_NAME}" --name "${MEMCACHED_HOST_1}" -d memcached:latest)
+mc2=$(docker run --rm --network "${NETWORK_NAME}" --name "${MEMCACHED_HOST_2}" -d memcached:latest)
+
+cleanup() {
+    if [ -n "${db}" ]; then
+        docker rm -f "${db}"
+    fi
+
+    if [ -n "${mc1}" ]; then
+        docker rm -f "${mc1}"
+    fi
+
+    if [ -n "${mc2}" ]; then
+        docker rm -f "${mc2}"
+    fi
+
+    if [ -z "${NETWORK_NAME_OVERRIDE}" ]; then
+        docker network rm "${NETWORK_NAME}"
+    fi
+}
+
+trap cleanup EXIT
+
+if [ -z "${CI}" ]; then
+    interactive="-it"
+else
+    interactive=""
+fi
+
+# shellcheck disable=SC2086,SC2248,SC2312 # ARGS and DOCKER_OPTIONS must not be quoted
+docker run \
+    ${interactive} \
+    --rm \
+    --network "${NETWORK_NAME}" \
+    -e WP_VERSION \
+    -e WP_MULTISITE \
+    -e PHP_VERSION \
+    -e PHP_OPTIONS \
+    -e PHPUNIT_VERSION \
+    -e MYSQL_USER \
+    -e MYSQL_PASSWORD \
+    -e MYSQL_DB="${MYSQL_DATABASE}" \
+    -e MYSQL_HOST \
+    -e XDEBUG_MODE=coverage \
+    -e MEMCACHED_HOST_1 \
+    -e MEMCACHED_HOST_2 \
+    ${DOCKER_OPTIONS} \
+    -v "$(pwd):/home/circleci/project" \
+    ghcr.io/automattic/vip-container-images/wp-test-runner:latest \
+    ${ARGS}

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "composer/installers": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7",
-    "yoast/phpunit-polyfills": "^1.0"
+    "yoast/phpunit-polyfills": "^1.0",
+    "phpunit/phpunit": "^9.5"
   },
   "config": {
     "platform": {
-      "php": "7.3"
+      "php": "7.4"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,24 +7,18 @@
         convertWarningsToExceptions="true"
 >
     <testsuites>
-        <testsuite>
+        <testsuite name="Unit Tests">
             <directory prefix="test-" suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <coverage>
+        <include>
             <file>./object-cache.php</file>
-            <exclude>
-                <directory>./vendor</directory>
-                <directory>./tests</directory>
-                <directory>./bin</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-        <log type="coverage-clover" target="./clover.xml"/>
-    </logging>
+        </include>
+        <report>
+            <clover outputFile="clover.xml"/>
+            <text outputFile="php://stdout"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -183,12 +183,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 	public function test_incr_fails_if_existing_item_is_non_numeric(): void {
 		$this->object_cache->add( 'foo2', 'non-numeric' );
-		if ( PHP_MAJOR_VERSION === 8 ) {
-			$this->expectException( TypeError::class );
-		} else {
-			$this->expectNotice();
-		}
-
+		$this->expectNotice();
 		$this->object_cache->incr( 'foo2', 1 );
 	}
 
@@ -231,12 +226,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 	public function test_decr_fails_if_existing_item_is_non_numeric(): void {
 		$this->object_cache->add( 'foo2', 'non-numeric' );
-		if ( PHP_MAJOR_VERSION === 8 ) {
-			$this->expectException( TypeError::class );
-		} else {
-			$this->expectNotice();
-		}
-
+		$this->expectNotice();
 		$this->object_cache->decr( 'foo2', 1 );
 	}
 

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -172,22 +172,24 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 	public function test_incr_fails_if_non_numeric_value_is_passed(): void {
 		$this->object_cache->add( 'foo2', 1 );
-		try {
-			$incremented = $this->object_cache->incr( 'foo2', 'non-numeric' );
-			$this->fail( 'Incrementing should have failed due to non-numeric modifier.' );
-		} catch ( \Exception $e ) {
-			// Expected to come in here, no output needed.
+		if ( PHP_MAJOR_VERSION === 8 ) {
+			$this->expectException( TypeError::class );
+		} else {
+			$this->expectWarning();
 		}
+	
+		$this->object_cache->incr( 'foo2', 'non-numeric' );
 	}
 
 	public function test_incr_fails_if_existing_item_is_non_numeric(): void {
 		$this->object_cache->add( 'foo2', 'non-numeric' );
-		try {
-			$incremented = $this->object_cache->incr( 'foo2', 1 );
-			$this->fail( 'Incrementing should have failed due to non-numeric item.' );
-		} catch ( \Exception $e ) {
-			// Expected to come in here, no output needed.
+		if ( PHP_MAJOR_VERSION === 8 ) {
+			$this->expectException( TypeError::class );
+		} else {
+			$this->expectNotice();
 		}
+
+		$this->object_cache->incr( 'foo2', 1 );
 	}
 
 	public function test_incr_can_be_performed_per_group(): void {

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -7,12 +7,19 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 	 */
 	private $object_cache;
 
-	public function setUp() {
-		$GLOBALS['memcached_servers'] = array( '127.0.0.1:11211', '127.0.0.1:11212' );
+	public function setUp(): void {
+		parent::setUp();
+		$host1 = getenv( 'MEMCACHED_HOST_1' );
+		$host2 = getenv( 'MEMCACHED_HOST_2' );
+
+		$host1 = $host1 ? "{$host1}:11211" : 'localhost:11211';
+		$host2 = $host2 ? "{$host2}:11211" : 'localhost:11212';
+
+		$GLOBALS['memcached_servers'] = array( $host1, $host2 );
 		$GLOBALS['wp_object_cache'] = $this->object_cache = new WP_Object_Cache();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->object_cache->flush();
 	}
 
@@ -759,7 +766,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 	// Tests for key.
 
 	public function test_key_returns_cache_key_for_default_group_if_no_group_passed(): void {
-		$this->assertContains( 'default:foo', $this->object_cache->key( 'foo', '') );
+		$this->assertStringContainsString( 'default:foo', $this->object_cache->key( 'foo', '') );
 	}
 
 	public function test_key_contains_global_prefix_when_using_global_group(): void {
@@ -767,13 +774,13 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		// Have to set global prefix here as without multi site it is set to the same value as blog prefix.
 		$this->object_cache->global_prefix = 'global_prefix';
-		$this->assertContains( $this->object_cache->global_prefix, $this->object_cache->key( 'foo', 'global-group') );
+		$this->assertStringContainsString( $this->object_cache->global_prefix, $this->object_cache->key( 'foo', 'global-group') );
 	}
 
 	public function test_key_contains_blog_prefix_when_using_non_global_group(): void {
 		// Have to set blog prefix here as without multi site it is set to the same value as global prefix.
 		$this->object_cache->blog_prefix = 'blog_prefix';
-		$this->assertContains( $this->object_cache->blog_prefix, $this->object_cache->key( 'foo', 'non-global-group') );
+		$this->assertStringContainsString( $this->object_cache->blog_prefix, $this->object_cache->key( 'foo', 'non-global-group') );
 	}
 
 	// Tests for replace.
@@ -1017,6 +1024,6 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 	public function test_colorize_debug_line( $command, $expected_color ) {
 		$colorized = $this->object_cache->colorize_debug_line( $command );
 
-		$this->assertContains( $expected_color, $colorized );
+		$this->assertStringContainsString( $expected_color, $colorized );
 	}
 }

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -220,22 +220,24 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 	public function test_decr_fails_if_non_numeric_value_is_passed(): void {
 		$this->object_cache->add( 'foo2', 1 );
-		try {
-			$decremented = $this->object_cache->decr( 'foo2', 'non-numeric' );
-			$this->fail( 'Decrementing should have failed due to non-numeric modifier.' );
-		} catch ( \Exception $e ) {
-			// Expected to come in here, no output needed.
+		if ( PHP_MAJOR_VERSION === 8 ) {
+			$this->expectException( TypeError::class );
+		} else {
+			$this->expectWarning();
 		}
+
+		$this->object_cache->decr( 'foo2', 'non-numeric' );
 	}
 
 	public function test_decr_fails_if_existing_item_is_non_numeric(): void {
 		$this->object_cache->add( 'foo2', 'non-numeric' );
-		try {
-			$decremented = $this->object_cache->decr( 'foo2', 1 );
-			$this->fail( 'Decrementing should have failed due to non-numeric item.' );
-		} catch ( \Exception $e ) {
-			// Expected to come in here, no output needed.
+		if ( PHP_MAJOR_VERSION === 8 ) {
+			$this->expectException( TypeError::class );
+		} else {
+			$this->expectNotice();
 		}
+
+		$this->object_cache->decr( 'foo2', 1 );
 	}
 
 	public function test_decr_can_be_performed_per_group(): void {


### PR DESCRIPTION
This PR does several things:
* updates PHPUnit to 9.0 - this is what the recent WordPress expects; PHPUnit 5.x is too old; `phpunit.xml` had to be migrated;
* drops PHP 7.3 and adds PHP 8.0 to CI;
* adds support to run unit tests in a Docker container.

Bonuses:
* compatibility with PHP 8;
* fix risky tests (they are no longer risky)
