### PR TITLE
Fix code coverage generation

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,9 @@ if ( ! $_core_dir ) {
 require_once $_tests_dir . '/includes/functions.php';
 
 // Copy across the drop-in plugin.
-copy( dirname( __DIR__ ) . '/object-cache.php', $_core_dir . '/wp-content/object-cache.php' );
+$fname   = dirname( __DIR__ ) . '/object-cache.php';
+$content = "<?php require_once '{$fname}';";
+file_put_contents( $_core_dir . '/wp-content/object-cache.php', $content );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
PHPUnit refuses to generate a coverage report for `object-cache.php` moved to another directory ([example](https://travis-ci.org/github/Automattic/wp-memcached/jobs/774814300#L574)). This PR updates the test bootstrap to create `wp-content/object-cache.php` that `require_once` our `object-cache.php`. This way, the coverage is generated for the original file, and PHPUnit can process it.
