### PR TITLE
GH-79: Implement `wp_cache_(add|delete|set)_multiple`

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -22,6 +22,12 @@ function wp_cache_add( $key, $data, $group = '', $expire = 0 ) {
 	return $wp_object_cache->add( $key, $data, $group, $expire );
 }
 
+function wp_cache_add_multiple( array $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+
+	return $wp_object_cache->add_multiple( $data, $group, $expire );
+}
+
 function wp_cache_incr( $key, $n = 1, $group = '' ) {
 	global $wp_object_cache;
 
@@ -44,6 +50,12 @@ function wp_cache_delete( $key, $group = '' ) {
 	global $wp_object_cache;
 
 	return $wp_object_cache->delete( $key, $group );
+}
+
+function wp_cache_delete_multiple( array $keys, $group = '' ) {
+	global $wp_object_cache;
+
+	return $wp_object_cache->delete_multiple( $keys, $group );
 }
 
 function wp_cache_flush() {
@@ -96,6 +108,12 @@ function wp_cache_set( $key, $data, $group = '', $expire = 0 ) {
 	} else {
 		return $wp_object_cache->delete( $key, $group );
 	}
+}
+
+function wp_cache_set_multiple( array $data, $group = '', $expire = 0 ) {
+	global $wp_object_cache;
+
+	return $wp_object_cache->set_multiple( $data, $group, $expire );
 }
 
 function wp_cache_switch_to_blog( $blog_id ) {
@@ -204,6 +222,16 @@ class WP_Object_Cache {
 		return $result;
 	}
 
+	public function add_multiple( array $data, $group = '', $expire = 0 ) {
+		$values = array();
+
+		foreach ( $data as $key => $value ) {
+			$values[ $key ] = $this->add( $key, $value, $group, $expire );
+		}
+
+		return $values;
+	}
+
 	function add_global_groups( $groups ) {
 		if ( ! is_array( $groups ) ) {
 			$groups = (array) $groups;
@@ -277,6 +305,16 @@ class WP_Object_Cache {
 		}
 
 		return $result;
+	}
+
+	public function delete_multiple( array $keys, $group = '' ) {
+		$values = array();
+
+		foreach ( $keys as $key ) {
+			$values[ $key ] = $this->delete( $key, $group );
+		}
+
+		return $values;
 	}
 
 	// Gets number from all default servers, replicating if needed
@@ -625,6 +663,16 @@ class WP_Object_Cache {
 		$this->cache[ $key ][ 'found' ] = $result;
 
 		return $result;
+	}
+
+	public function set_multiple( array $data, $group = '', $expire = 0 ) {
+		$values = array();
+
+		foreach ( $data as $key => $value ) {
+			$values[ $key ] = $this->set( $key, $value, $group, $expire );
+		}
+
+		return $values;
 	}
 
 	function switch_to_blog( $blog_id ) {

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -1026,4 +1026,61 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( $expected_color, $colorized );
 	}
+
+	public function test_wp_cache_add_multiple() {
+		$found = wp_cache_add_multiple(
+			array(
+				'foo1' => 'bar',
+				'foo2' => 'bar',
+				'foo3' => 'bar',
+			),
+			'group1'
+		);
+
+		$expected = array(
+			'foo1' => true,
+			'foo2' => true,
+			'foo3' => true,
+		);
+
+		$this->assertSame( $expected, $found );
+	}
+
+	public function test_wp_cache_set_multiple() {
+		$found = wp_cache_set_multiple(
+			array(
+				'foo1' => 'bar',
+				'foo2' => 'bar',
+				'foo3' => 'bar',
+			),
+			'group1'
+		);
+
+		$expected = array(
+			'foo1' => true,
+			'foo2' => true,
+			'foo3' => true,
+		);
+
+		$this->assertSame( $expected, $found );
+	}
+
+	public function test_wp_cache_delete_multiple() {
+		wp_cache_set( 'foo1', 'bar', 'group1' );
+		wp_cache_set( 'foo2', 'bar', 'group1' );
+		wp_cache_set( 'foo3', 'bar', 'group2' );
+
+		$found = wp_cache_delete_multiple(
+			array( 'foo1', 'foo2', 'foo3' ),
+			'group1'
+		);
+
+		$expected = array(
+			'foo1' => true,
+			'foo2' => true,
+			'foo3' => false,
+		);
+
+		$this->assertSame( $expected, $found );
+	}
 }


### PR DESCRIPTION
This PR adds support for `wp_cache_add_multiple()`, `wp_cache_delete_multiple()`, and `wp_cache_set_multiple()` functions introduced in WP 6.0.

However, because `Memcache` PHP extension does not support `multi` methods, this PR does not bring performance improvements.

Closes: #79 

