### PR TITLE
GH-63: Implement wp_cache_get_multiple()

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -600,7 +600,7 @@ class WP_Object_Cache {
 	public function get_multiple( $ids, $group = 'default', $force = false ) {
 		$mc = $this->get_mc( $group );
 
-		$no_mc = in_array( $group, $this->no_mc_groups );
+		$no_mc = in_array( $group, $this->no_mc_groups, true );
 
 		$uncached_keys = array();
 
@@ -771,6 +771,7 @@ class WP_Object_Cache {
 			'get' => 'green',
 			'get_local' => 'lightgreen',
 			'get_multi' => 'fuchsia',
+			'get_multiple' => 'navy',
 			'set' => 'purple',
 			'set_local' => 'orchid',
 			'add' => 'blue',

--- a/object-cache.php
+++ b/object-cache.php
@@ -505,7 +505,7 @@ class WP_Object_Cache {
 				 * In PHP 8, they changed the way memcache_get() handles `null`:
 				 * https://github.com/websupport-sk/pecl-memcache/blob/ccf702b14b18fce18a1863e115a7b4c964df952e/src/memcache.c#L2175-L2177
 				 *
-				 * If the return value is `null`, it is silently converted to `false`. We can only rely upon $flags to find out whther `false` is real.
+				 * If the return value is `null`, it is silently converted to `false`. We can only rely upon $flags to find out whether `false` is real.
 				 */
 				$value = null;
 			}

--- a/object-cache.php
+++ b/object-cache.php
@@ -489,6 +489,25 @@ class WP_Object_Cache {
 			if ( false === $flags ) {
 				$found = false;
 				$value = false;
+			} elseif ( false === $value && ( $flags & 0xFF01 ) === 0x01 ) {
+				/*
+				 * The lowest byte is used for flags.
+				 * 0x01 means the value is serialized (MMC_SERIALIZED).
+				 * The second lowest indicates data type: 0 is string, 1 is bool, 3 is long, 7 is double.
+				 * `null` is serialized into a string, thus $flags is 0x0001
+				 * Empty string will correspond to $flags = 0x0000 (not serialized).
+				 * For `false` or `true` $flags will be 0x0100
+				 *
+				 * See:
+				 * - https://github.com/websupport-sk/pecl-memcache/blob/2a5de3c5d9c0bd0acbcf7e6e0b7570f15f89f55b/php7/memcache_pool.h#L61-L76 - PHP 7.x
+				 * - https://github.com/websupport-sk/pecl-memcache/blob/ccf702b14b18fce18a1863e115a7b4c964df952e/src/memcache_pool.h#L57-L76 - PHP 8.x
+				 *
+				 * In PHP 8, they changed the way memcache_get() handles `null`:
+				 * https://github.com/websupport-sk/pecl-memcache/blob/ccf702b14b18fce18a1863e115a7b4c964df952e/src/memcache.c#L2175-L2177
+				 *
+				 * If the return value is `null`, it is silently converted to `false`. We can only rely upon $flags to find out whther `false` is real.
+				 */
+				$value = null;
 			}
 
 			$this->cache[ $key ] = [

--- a/object-cache.php
+++ b/object-cache.php
@@ -597,17 +597,16 @@ class WP_Object_Cache {
 		return $return;
 	}
 
-	public function get_multiple( $ids, $group = 'default', $force = false ) {
+	public function get_multiple( $keys, $group = 'default', $force = false ) {
 		$mc = $this->get_mc( $group );
 
 		$no_mc = in_array( $group, $this->no_mc_groups, true );
 
 		$uncached_keys = array();
+		$return        = array();
+		$return_cache  = array();
 
-		$return = array();
-		$return_cache = array();
-
-		foreach ( $ids as $id ) {
+		foreach ( $keys as $id ) {
 			$key = $this->key( $id, $group );
 
 			if ( isset( $this->cache[ $key ] ) && ( ! $force || $no_mc ) ) {

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -1132,4 +1132,45 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		$actual = wp_cache_get_multiple( [ 'foo' ], $group );
 		$this->assertSame( $expected, $actual );
 	}
+
+	public function test_wp_cache_get_multiple_consistency() {
+		$values = [
+			'empty-string' => '',
+			'empty-array'  => [],
+			'zero'         => 0,
+			'false'        => false,
+			'null'         => null,
+		];
+
+		foreach ( $values as $key => $value ) {
+			$result = wp_cache_set( $key, $value, 'group' );
+			self::assertTrue( $result );
+		}
+
+		$actual = wp_cache_get_multiple( array_keys( $values ), 'group', true );
+		self::assertSame( $values, $actual );
+	}
+
+	/**
+	 * @dataProvider data_wp_cache_get_consistency
+	 */
+	public function test_wp_cache_get_consistency( $value ) {
+		$result = wp_cache_set( 'key', $value, 'group' );
+		self::assertTrue( $result );
+
+		$found  = false;
+		$actual = wp_cache_get( 'key', 'group', true, $found );
+		self::assertTrue( $found );
+		self::assertSame( $value, $actual );
+	}
+
+	public function data_wp_cache_get_consistency() {
+		return [
+			'empty string' => [ '' ],
+			'empty array'  => [ [] ],
+			'zero'         => [ 0 ],
+			'false'        => [ false ],
+			'null'         => [ null ],
+		];
+	}
 }

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -1114,4 +1114,22 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $found );
 	}
+
+	public function test_wp_cache_get_multiple_np() {
+		$group = 'do-not-persist-me';
+
+		$added = $this->object_cache->set( 'foo', 'data 1', $group );
+		$this->assertTrue( $added );
+
+		$this->object_cache->add_non_persistent_groups( [ $group ] );
+
+		$this->object_cache->cache = [];
+
+		$expected = [
+			'foo' => false,
+		];
+
+		$actual = wp_cache_get_multiple( [ 'foo' ], $group );
+		$this->assertSame( $expected, $actual );
+	}
 }

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -1098,4 +1098,20 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $found );
 	}
+
+	public function test_wp_cache_get_multiple() {
+		wp_cache_set( 'foo1', 'bar', 'group1' );
+		wp_cache_set( 'foo2', 'bar', 'group1' );
+		wp_cache_set( 'foo1', 'bar', 'group2' );
+
+		$found = wp_cache_get_multiple( array( 'foo1', 'foo2', 'foo3' ), 'group1' );
+
+		$expected = array(
+			'foo1' => 'bar',
+			'foo2' => 'bar',
+			'foo3' => false,
+		);
+
+		$this->assertSame( $expected, $found );
+	}
 }


### PR DESCRIPTION
This PR adds support for the `wp_cache_get_multiple()` function introduced in WordPress 5.5.

Fixes #63
