### PR TITLE
Speed up CI

### DIFF
--- a/.github/install-wp-tests.sh
+++ b/.github/install-wp-tests.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+set -e
+
+download_wp() {
+	VERSION="$1"
+	if [ "${VERSION}" = "nightly" ] || [ "${VERSION}" = "trunk" ]; then
+		TESTS_TAG="trunk"
+	elif [ "${VERSION}" = "latest" ]; then
+		VERSIONS=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - )
+		LATEST=$(echo "${VERSIONS}" | jq -r '.offers | map(select( .response == "upgrade")) | .[0].version')
+		if [ -z "${LATEST}" ]; then
+			echo "Unable to detect the latest WP version"
+			exit 1
+		fi
+
+		download_wp "${LATEST}"
+		ln -sf "/tmp/wordpress-${LATEST}" /tmp/wordpress-latest
+		ln -sf "/tmp/wordpress-tests-lib-${LATEST}" /tmp/wordpress-tests-lib-latest
+		return
+	elif [ "${VERSION%.x}" != "${VERSION}" ]; then
+		VER="${VERSION}"
+		LATEST=$(wget https://api.wordpress.org/core/version-check/1.7/ -q -O - | jq --arg version "${VERSION%.x}" -r '.offers | map(select(.version | startswith($version))) | sort_by(.version) | reverse | .[0].version')
+		download_wp "${LATEST}"
+		ln -sf "/tmp/wordpress-${LATEST}" "/tmp/wordpress-${VER}"
+		ln -sf "/tmp/wordpress-tests-lib-${LATEST}" "/tmp/wordpress-tests-lib-${VER}"
+		return
+	else
+		TESTS_TAG="tags/${VERSION}"
+	fi
+
+	if [ ! -d "/tmp/wordpress-${VERSION}" ]; then
+		if [ "${VERSION}" = "nightly" ]; then
+			cd /tmp
+			wget -q https://wordpress.org/nightly-builds/wordpress-latest.zip
+			unzip -q wordpress-latest.zip
+			mv /tmp/wordpress /tmp/wordpress-nightly
+			rm -f wordpress-latest.zip
+			cd -
+		else
+			mkdir -p "/tmp/wordpress-${VERSION}"
+			wget -q "https://wordpress.org/wordpress-${VERSION}.tar.gz" -O - | tar --strip-components=1 -zxm -f - -C "/tmp/wordpress-${VERSION}"
+		fi
+		wget -q https://raw.github.com/markoheijnen/wp-mysqli/master/db.php -O "/tmp/wordpress-${VERSION}/wp-content/db.php"
+	else
+		echo "Skipping WordPress download"
+	fi
+
+	if [ ! -d "/tmp/wordpress-tests-lib-${VERSION}" ]; then
+		mkdir -p "/tmp/wordpress-tests-lib-${VERSION}"
+		svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${TESTS_TAG}/tests/phpunit/includes/" "/tmp/wordpress-tests-lib-${VERSION}/includes"
+		svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${TESTS_TAG}/tests/phpunit/data/" "/tmp/wordpress-tests-lib-${VERSION}/data"
+		rm -f "/tmp/wordpress-tests-lib-${VERSION}/wp-tests-config-sample.php"
+		wget -q "https://develop.svn.wordpress.org/${TESTS_TAG}/wp-tests-config-sample.php" -O "/tmp/wordpress-tests-lib-${VERSION}/wp-tests-config-sample.php"
+	else
+		echo "Skipping WordPress test library download"
+	fi
+}
+
+export WP_VERSION="${WP_VERSION:-"latest"}"
+export DB_USER="${DB_USER:-"root"}"
+export DB_PASSWORD="${DB_PASSWORD:-""}"
+export DB_NAME="${DB_NAME:-"wordpress_test"}"
+export DB_HOST="${DB_HOST:-"127.0.0.1"}"
+
+download_wp "${WP_VERSION}"
+
+echo "Waiting for MySQL..."
+while ! mysqladmin ping -h "${DB_HOST}" --silent; do
+	sleep 1
+done
+
+mysqladmin create "${DB_NAME}" --user="${DB_USER}" --password="${DB_PASSWORD}" --host="${DB_HOST}" || true
+
+(
+	cd "/tmp/wordpress-tests-lib-${WP_VERSION}" && \
+	cp -f wp-tests-config-sample.php wp-tests-config.php && \
+	sed -i "s/youremptytestdbnamehere/${DB_NAME}/; s/yourusernamehere/${DB_USER}/; s/yourpasswordhere/${DB_PASSWORD}/; s|localhost|${DB_HOST}|" wp-tests-config.php && \
+	sed -i "s:dirname( __FILE__ ) . '/src/':'/tmp/wordpress/':" wp-tests-config.php
+)
+
+rm -rf /tmp/wordpress /tmp/wordpress-tests-lib
+ln -sf "/tmp/wordpress-${WP_VERSION}" /tmp/wordpress
+ln -sf "/tmp/wordpress-tests-lib-${WP_VERSION}" /tmp/wordpress-tests-lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,25 @@ jobs:
             wordpress: "5.7.x"
           - php: "8.0"
             wordpress: "5.8.x"
+    services:
+      mysql:
+        image: mariadb:10.3
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ROOT_PASSWORD: wordpress
+          MARIADB_INITDB_SKIP_TZINFO: 1
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+          MYSQL_DATABASE: wordpress_test
+      memcached_1:
+        image: memcached:alpine
+        ports:
+          - "11211:11211"
+      memcached_2:
+        image: memcached:alpine
+        ports:
+          - "11212:11211"
     steps:
       - name: Check out source code
         uses: actions/checkout@v3.0.2
@@ -48,31 +67,40 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@2.18.1
         with:
-          coverage: none
+          coverage: xdebug
           php-version: ${{ matrix.php }}
 
       - name: Install PHP Dependencies
         uses: ramsey/composer-install@2.1.0
 
-      - name: Create coverage directory
-        run: mkdir -m 0777 coverage
+      - name: Install WP Test Suite
+        run: ./.github/install-wp-tests.sh
+        env:
+          WP_VERSION: ${{ matrix.wordpress }}
+          DB_NAME: wordpress_test
+          DB_USER: wordpress
+          DB_PASSWORD: wordpress
+          DH_HOST: 127.0.0.1
 
       - name: Run tests
         run: |
           if [ "${{ matrix.multisite }}" == "yes" ]; then
-            MULTISITE=1
-          else
-            MULTISITE=0
+            export WP_MULTISITE=1
           fi
           if echo "${{ matrix.wordpress }}" | grep -qE '^5\.[5-8]'; then
-            PHPUNIT=7
+            wget -q -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-7.phar
           else
-            PHPUNIT=9
+            wget -q -O /usr/local/bin/phpunit https://phar.phpunit.de/phpunit-9.phar
           fi
-          ./bin/test.sh --wp "${{ matrix.wordpress }}" --php "${{ matrix.php }}" --multisite "${MULTISITE}" --phpunit "${PHPUNIT}" --order-by=random
+          chmod +x /usr/local/bin/phpunit
+          phpunit
+        env:
+          MEMCACHED_HOST_1: 127.0.0.1:11211
+          MEMCACHED_HOST_2: 127.0.0.1:11212
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
         with:
           files: coverage/clover.xml
           flags: unittests
+        if: ${{ matrix.wordpress == 'latest' }}

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -12,8 +12,8 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		$host1 = getenv( 'MEMCACHED_HOST_1' );
 		$host2 = getenv( 'MEMCACHED_HOST_2' );
 
-		$host1 = $host1 ? "{$host1}:11211" : 'localhost:11211';
-		$host2 = $host2 ? "{$host2}:11211" : 'localhost:11212';
+		$host1 = $host1 ? "{$host1}" : 'localhost:11211';
+		$host2 = $host2 ? "{$host2}" : 'localhost:11212';
 
 		$GLOBALS['memcached_servers'] = array( $host1, $host2 );
 		$GLOBALS['wp_object_cache'] = $this->object_cache = new WP_Object_Cache();


### PR DESCRIPTION
The CI takes now 34 seconds instead of 1 minute.

The speedup is achieved by using `services` (while MySQL starts up, we do other useful things like check out the source code or install dependencies) and by not using the `wp-test-runner` image (it takes some time to download it).
