### PR TITLE
Fix "Undefined offset: 1" when no port specified

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -919,6 +919,7 @@ class WP_Object_Cache {
 
 		$keys = $this->strip_memcached_keys( $keys );
 
+		// @codeCoverageIgnoreStart
 		if ( $time > $this->slow_op_microseconds && 'get_multi' !== $op ) {
 			$this->increment_stat( 'slow-ops' );
 			$backtrace = null;
@@ -927,6 +928,7 @@ class WP_Object_Cache {
 			}
 			$this->group_ops['slow-ops'][] = array( $op, $keys, $size, $time, $comment, $group, $backtrace );
 		}
+		// @codeCoverageIgnoreEnd
 
 		$this->group_ops[ $group ][] = array( $op, $keys, $size, $time, $comment );
 	}

--- a/object-cache.php
+++ b/object-cache.php
@@ -858,10 +858,11 @@ class WP_Object_Cache {
 					$node = $server;
 					$port = 0;
 				} else {
-					list ( $node, $port ) = explode( ':', $server );
-
-					if ( ! $port ) {
+					if ( false === strpos( $server, ':' ) ) {
+						$node = $server;
 						$port = ini_get( 'memcache.default_port' );
+					} else {
+						list ( $node, $port ) = explode( ':', $server, 2 );
 					}
 
 					$port = intval( $port );

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -24,7 +24,7 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 	}
 
 	public function test_server_without_port() {
-		$GLOBALS['memcached_servers'] = array( 'localhost' );
+		$GLOBALS['memcached_servers'] = array( 'localhost', 'localhost:0' );
 		new WP_Object_Cache(); // NOSONAR
 		self::assertTrue( true );
 	}

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -23,6 +23,12 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		$this->object_cache->flush();
 	}
 
+	public function test_server_without_port() {
+		$GLOBALS['memcached_servers'] = array( 'localhost' );
+		new WP_Object_Cache(); // NOSONAR
+		self::assertTrue( true );
+	}
+
 	// Tests for adding.
 
 	public function test_add_returns_true_if_added_successfully(): void {


### PR DESCRIPTION
If `$server` is specified without the port (relying upon `memcache.default_port`), the code spits a notice "Undefined offset: 1". This PR fixes that notice.
