### PR TITLE
add() should not overwrite non-persistent keys

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -155,13 +155,19 @@ class WP_Object_Cache {
 		}
 
 		if ( in_array( $group, $this->no_mc_groups ) ) {
-			$this->cache[ $key ] = [
-				'value' => $data,
-				'found' => false,
-			];
+			if ( ! isset( $this->cache[ $key ] ) ) {
+				$this->cache[ $key ] = [
+					'value' => $data,
+					'found' => false,
+				];
 
-			return true;
-		} elseif ( isset( $this->cache[ $key ][ 'value' ] ) && false !== $this->cache[ $key ][ 'value' ] ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		if ( isset( $this->cache[ $key ][ 'value' ] ) && false !== $this->cache[ $key ][ 'value' ] ) {
 			return false;
 		}
 

--- a/tests/test-object-cache.php
+++ b/tests/test-object-cache.php
@@ -93,6 +93,21 @@ class Test_WP_Object_Cache extends WP_UnitTestCase {
 		$this->assertEquals( $expected_cache , $this->object_cache->cache[ $key ] );
 	}
 
+	public function test_add_for_np_groups_does_not_overwrite(): void {
+		$group    = 'do-not-persist-me';
+		$expected = 123;
+
+		$this->object_cache->add_non_persistent_groups( [ $group ] );
+		$added = $this->object_cache->add( 'foo', $expected, $group );
+		self::assertTrue( $added );
+
+		$added = $this->object_cache->add( 'foo', $expected * 2, $group );
+		self::assertFalse( $added );
+
+		$actual = $this->object_cache->get( 'foo', $group );
+		self::assertEquals( $expected, $actual );
+	}
+
 	public function test_add_local_cache_is_unset_on_memcache_failure(): void {
 		$this->markTestSkipped( 'Unable to test without refactoring to inject a Memcache instance.' );
 	}


### PR DESCRIPTION
The semantics of `add()` is that it sets the key if it does not exist. However, this was not true for non-persistent groups. This PR fixes that.