### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
   "config": {
     "platform": {
       "php": "7.4"
+    },
+    "allow-plugins": {
+      "composer/installers": true
     }
   }
 }


### PR DESCRIPTION
GitHub's composer [started to fail](https://github.com/Automattic/wp-memcached/runs/7223037884?check_suite_focus=true#step:7:125) the jobs with

> Error: composer/installers contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
> You can run "composer config --no-plugins allow-plugins.composer/installers [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
> See https://getcomposer.org/allow-plugins

This PR fixes that.