### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
         id: coverage
         run: |
           if [ "${{ matrix.config.coverage }}" = "yes" ]; then
-            echo "::set-output name=coverage::xdebug"
+            echo "coverage=xdebug" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=coverage::none"
+            echo "coverage=none" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up PHP


### PR DESCRIPTION
GitHub has [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the `set-output` and `save-state` commands. This PR updates our workflows to use the [suggested replacement](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).
