### PR TITLE
Guard the call to apply_filters() incase it's unavailable

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -73,10 +73,12 @@ function wp_cache_flush_runtime() {
 function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
 	global $wp_object_cache;
 
-	$value = apply_filters( 'pre_wp_cache_get', false, $key, $group, $force );
-	if ( false !== $value ) {
-		$found = true;
-		return $value;
+	if ( function_exists( 'apply_filters' ) ) {
+		$value = apply_filters( 'pre_wp_cache_get', false, $key, $group, $force );
+		if ( false !== $value ) {
+			$found = true;
+			return $value;
+		}
 	}
 
 	return $wp_object_cache->get( $key, $group, $force, $found );


### PR DESCRIPTION
On WordPress.org we use the object cache in places that sometimes operate with a minimal environment, and may not have apply_filters() loaded.

While this is a minimal change, and loading `plugin.php` for those environments might be ideal instead, the rest of the class appears to have minimal other dependencies. 