### PR TITLE
Readme: Clarify that need `memcache` extension, not `memcached`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,15 +6,15 @@ Tested up to: 6.0
 Stable tag: 4.0.0
 Requires PHP: 7.4.0
 
-Use memcached and the PECL memcache extension to provide a backing store for the WordPress object cache.
+Use memcached (with the `d`) and the PECL memcache (without `d`) extension to provide a backing store for the WordPress object cache.
 
 == Description ==
-Memcached Object Cache provides a persistent backend for the WordPress object cache. A memcached server and the PECL memcache extension are required.
+Memcached Object Cache provides a persistent backend for the WordPress object cache. A memcached server (with the `d`) and the PECL memcache (without `d`) extension are required.
 
 == Installation ==
-1. Install [memcached](http://danga.com/memcached) on at least one server. Note the connection info. The default is `127.0.0.1:11211`.
+1. Install [memcached](http://danga.com/memcached) (with the `d`) on at least one server. Note the connection info. The default is `127.0.0.1:11211`.
 
-1. Install the [PECL memcache extension](http://pecl.php.net/package/memcache)
+1. Install the [PECL memcache extension](http://pecl.php.net/package/memcache) (without `d`).
 
 1. Copy object-cache.php to wp-content
 
@@ -80,6 +80,13 @@ users
 userslugs
 widget
 `
+
+= Why am I getting a `Class "Memcache" not found` error? =
+
+You need to install the [PECL memcache extension](http://pecl.php.net/package/memcache). Make sure it's `memcache` (no `d`) rather than `memcached` (with `d`).
+
+Make sure it's loaded in your `php.ini` and `php-cli.ini` files. It's a regular `extension` rather than a `zend_extension`.
+
 
 == Changelog ==
 


### PR DESCRIPTION
The two names are very similar, and it's easy for a user to assume the `memcached` extension should be installed because the plugin is named `memcached`, and the readme mostly references `memcached`.

The general changes and FAQ address #38. The FAQ also addresses #148.

Related #6  / #133. This PR won't be needed if that one is merged, but there's currently no movement there. This is a simple readme-only change, so I think it's good to do this now, and then it can be revised if that PR is merged.