### PR TITLE
Exclude build+test files from ZIP package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Files not needed to be distributed in ZIP packages.
+/.github/         export-ignore
+/bin/             export-ignore
+/tests/           export-ignore
+/.*               export-ignore
+/composer.json    export-ignore
+/phpunit.xml      export-ignore


### PR DESCRIPTION
Up until wp-memcached 3.0.2 there weren't any such files in the Git repository, but now that there are, we should exclude them from the package to avoid clutter in downstream embedded copies to ease auditing and reduce overall noise and size.

See also:
* https://github.com/Automattic/Co-Authors-Plus/blob/HEAD/.gitattributes
* https://github.com/Automattic/jetpack-autoloader/blob/HEAD/.gitattributes