### PR TITLE
Release 4.1.0

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Memcached
 Description: Memcached backend for the WP Object Cache.
-Version: 4.0.0
+Version: 4.1.0
 Plugin URI: https://wordpress.org/plugins/memcached/
 Author: Ryan Boren, Denis de Bernardy, Matt Martz, Andy Skelton
 

--- a/readme.txt
+++ b/readme.txt
@@ -83,7 +83,7 @@ widget
 
 == Changelog ==
 
-= 4.1.0
+= 4.1.0 =
 * Add support for `wp_cache_(add|delete|get|set)_multiple()`
 * Add support for `wp_cache_flush_runtime()`
 * Add support for `wp_cache_supports()`

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Memcached Object Cache ===
-Contributors: ryan, sivel, andy, nacin, barry, ethitter, nickdaugherty, batmoo, simonwheatley, jenkoian, bor0, aidvu
+Contributors: ryan, sivel, andy, nacin, barry, ethitter, nickdaugherty, batmoo, simonwheatley, jenkoian, bor0, aidvu, dd32
 Tags: cache, memcached
 Requires at least: 5.3
-Tested up to: 6.0
-Stable tag: 4.0.0
+Tested up to: 6.5
+Stable tag: 4.1.0
 Requires PHP: 7.4.0
 
 Use memcached and the PECL memcache extension to provide a backing store for the WordPress object cache.
@@ -82,6 +82,14 @@ widget
 `
 
 == Changelog ==
+
+= 4.1.0
+* Add support for `wp_cache_(add|delete|get|set)_multiple()`
+* Add support for `wp_cache_flush_runtime()`
+* Add support for `wp_cache_supports()`
+* PHP 8.2 compatibility fixes
+* Increase minimum PHP requirement to 7.4
+* Bump WP tested-up-to to 6.5
 
 = 4.0.0 =
 * Add preemptive filter pre_wp_cache_get


### PR DESCRIPTION
[v4.0 was released on Jul 24, 2021](https://github.com/Automattic/wp-memcached/releases/tag/4.0.0), it's probably about time for a new release, especially with the PHP 8.2 fixes.

This PR contains the changes needed to the Readme & Plugin file to make this happen.

The changes that would be included in the release are this: https://github.com/Automattic/wp-memcached/compare/4.0.0...master (plus this PR).

I've drafted a release: https://github.com/Automattic/wp-memcached/releases/tag/untagged-4d644ee8bdcb0576e6dc

I've requested a review from the folks who have contributed to the repository for review of this + the release notes above. 

Fixes #163