### PR TITLE
Bump setup-php action and restore CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.24.0
+        uses: shivammathur/setup-php@2.37.1
         with:
           coverage: ${{ steps.coverage.outputs.coverage }}
           php-version: ${{ matrix.config.php }}
@@ -92,6 +92,9 @@ jobs:
 
       - name: Install PHP Dependencies
         uses: ramsey/composer-install@2.2.0
+
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
 
       - name: Set up WordPress and WordPress Test Library
         uses: sjinks/setup-wordpress-test-library@1.1.14


### PR DESCRIPTION
## Summary

- Updates `shivammathur/setup-php` from `2.24.0` to `2.37.1` in the CI workflow.
- Targets the current GitHub Actions Dependabot alert for `shivammathur/setup-php < 2.37.1`.
- Installs `subversion` explicitly because the WordPress test-library setup action shells out to `svn`, and the current GitHub runner image no longer provides it by default.
- Leaves runtime plugin code unchanged.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`
- `composer validate --no-check-publish` passes with the existing deprecated SPDX license warning.
- `git diff --check`

## CI note

The first CI run failed before tests with `spawn svn ENOENT` in the WordPress test-library setup step. This update makes that runner dependency explicit and restarted CI.