### PR TITLE
Update WP_CACHE_KEY_SALT definition in readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Memcached Object Cache provides a persistent backend for the WordPress object ca
 1. Add the `WP_CACHE_KEY_SALT` constant to the `wp-config.php`:
 
 ```php
-define( 'WP_CACHE_KEY_SALT', '...long random string...' );
+define( 'WP_CACHE_KEY_SALT', 'cache-key-prefix:terminated-by:' );
 ```
 
 This helps prevent cache pollution when multiplte WordPress installs are using the same Memcached server. The value must be unique for each WordPress install.


### PR DESCRIPTION
Bad naming, WP_CACHE_KEY_SALT is not a salt 🧂 at all.

It is key prefix.

e.g. `site-name:`

@mahangu What do you think?